### PR TITLE
Implementing fixes for Unity 2021.3 LTS

### DIFF
--- a/Runtime/ChunkGraph/ChunkNode.cs
+++ b/Runtime/ChunkGraph/ChunkNode.cs
@@ -264,17 +264,18 @@ namespace LibreFracture
             var connectionsCount = connections.Count;
             if (connectionsCount == 0)
                 return;
-            var points = new Vector3[2* connectionsCount];
+            var points = new Vector3[2 * connectionsCount];
             int i = 0;
+            Gizmos.color = Color.blue;
             foreach(var connectedNode in connections.Keys)
             {
                 var otherCenterOfMass = connectedNode.Rigidbody.worldCenterOfMass;
                 points[i++] = centerOfMass;
                 points[i++] = otherCenterOfMass;
-            }
 
-            Gizmos.color = Color.blue;
-            Gizmos.DrawLineList(points);
+                //Draw gizmo line for connections
+                Gizmos.DrawLine(points[i], points[i++]);
+            }
         }
 
         #endregion

--- a/Runtime/LibreFracture.cs
+++ b/Runtime/LibreFracture.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using Unity.VisualScripting;
 using NvBlast;
 
 
@@ -162,7 +161,7 @@ namespace LibreFracture
                     chunkDistancePreview.UpdatePreview(0);
                     GameObject.DestroyImmediate(chunkDistancePreview);
                 }
-                chunk.GetOrAddComponent<ChunkNode>();
+                chunk.gameObject.AddComponent<ChunkNode>();
 
                 CreateColliderForChunk(chunk.gameObject);
             }
@@ -173,7 +172,8 @@ namespace LibreFracture
             if(!fracturedObject.TryGetComponent<Collider>(out _))
                 fracturedObject.AddComponent<MeshCollider>();
 
-            var fracture = fracturedObject.GetOrAddComponent<ChunkGraphManager>();
+            var fracture = fracturedObject.GetComponent<ChunkGraphManager>();
+            if (fracture == null) fracture = fracturedObject.AddComponent<ChunkGraphManager>();
             fracture.jointBreakForce = parameters.jointBreakForce;
             fracture.totalMass = parameters.totalObjectMass;
 


### PR DESCRIPTION
Addressed main issues brought up so far related to working in Unity 2021.3 and from a fresh download.

Changelog:
- Replaces "GetOrAddComponent" extension calls with base "GetComponent" & "AddComponent" function calls
- Implemented an alternative replacement for "Gizmos.DrawLineList" by using "Gizmos.DrawLine" in existing foreach loop

Closes #2 
Closes #3 